### PR TITLE
add AMD support

### DIFF
--- a/backgrid-select-all.js
+++ b/backgrid-select-all.js
@@ -6,9 +6,11 @@
   Licensed under the MIT @license.
 */
 (function (root, factory) {
-
-  // CommonJS
-  if (typeof exports == "object") {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(["backbone", "backgrid", "underscore"], factory);
+  } else if (typeof exports == "object") {
+    // CommonJS
     module.exports = factory(require("backbone"), require("backgrid"), require("underscore"));
   }
   // Browser


### PR DESCRIPTION
Adds AMD support. I should note that the extension still extends Backgrid via namespacing, it does not export/return anything. So, AMD users will no longer need to `shim` the extension, but they should not expect an export. Similar to how a jQuery plugin would be loaded with AMD.
