### PR TITLE
getSelectedModels does not break models' order

### DIFF
--- a/backgrid-select-all.js
+++ b/backgrid-select-all.js
@@ -269,9 +269,12 @@
     if (selectAllHeaderCell) {
       var selectedModels = selectAllHeaderCell.selectedModels;
       var collection = this.collection.fullCollection || this.collection;
-      for (var modelId in selectedModels) {
-        result.push(collection.get(modelId));
-      }
+      collection.each(function (model) {
+        var key = model.id || model.cid;
+        if (_.has(selectedModels, key)) {
+          result.push(model);
+        }
+      });
     }
 
     return result;

--- a/test/select-all.js
+++ b/test/select-all.js
@@ -374,7 +374,7 @@ describe("Grid#getSelectedModels", function () {
   });
 
   it("will return a list of selected models", function () {
-    var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+    var collection = new Backbone.Collection([{id: 1}, {id: 3}, {id: 2}]);
 
     var grid = new Backgrid.Grid({
       collection: collection,
@@ -395,18 +395,19 @@ describe("Grid#getSelectedModels", function () {
     });
 
     var selectedModels = grid.getSelectedModels();
-    expect(selectedModels.length).toBe(2);
+    expect(selectedModels.length).toBe(3);
     expect(selectedModels[0].id).toBe(1);
-    expect(selectedModels[1].id).toBe(2);
+    expect(selectedModels[1].id).toBe(3);
+    expect(selectedModels[2].id).toBe(2);
   });
 
   it("will return a list of selected models across pageable pages", function(){
-    var pageable = new Backbone.PageableCollection([{id:1}, {id:2}, {id:3}], {
+    var pageable = new Backbone.PageableCollection([{id:1}, {id:3}, {id:2}], {
       state: { pageSize: 2 },
       mode: "client"
     });
     var one = pageable.get(1);
-    var three = pageable.fullCollection.get(3);
+    var two = pageable.fullCollection.get(3);
 
     var grid = new Backgrid.Grid({
       collection: pageable,
@@ -424,13 +425,13 @@ describe("Grid#getSelectedModels", function () {
 
     one.trigger("backgrid:selected", one, true);
     pageable.getLastPage();
-    three.trigger("backgrid:selected", three, true);
+    two.trigger("backgrid:selected", two, true);
 
     var selectedModels = grid.getSelectedModels();
 
     expect(selectedModels.length).toBe(2);
     expect(selectedModels[0]).toBe(one);
-    expect(selectedModels[1]).toBe(three);
+    expect(selectedModels[1]).toBe(two);
   });
 
 });


### PR DESCRIPTION
The Array.<Backbone.Model> returned by getSelectedModels should keep the order in which the original Backbone.Collection was ordered